### PR TITLE
Remove support for end-of-life Pythons

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 install:
   - "%PYTHON%\\python.exe -m pip install pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: python
 
 matrix:
     include:
-        - python: 2.7
-          env: TOXENV=py27
-        - python: 3.5
-          env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: pypy2.7-5.8.0
-          env: TOXENV=pypy
+        - python: 3.7
+          env: TOXENV=py37
+        - python: 3.8
+          env: TOXENV=py38
+        - python: 3.9
+          env: TOXENV=py396
         - python: pypy3.5-5.8.0
           env: TOXENV=pypy3
 

--- a/binary/core.py
+++ b/binary/core.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from collections import namedtuple
 
 from .utils import Decimal
@@ -102,7 +100,7 @@ DecimalUnits = namedtuple(
 
 
 def convert_units(n, unit=BYTE, to=None, si=False, exact=False):
-    """Converts between and within binary and decimal units. If no ``unit``
+    r"""Converts between and within binary and decimal units. If no ``unit``
     is specified, ``n`` is assumed to already be in bytes. If no ``to`` is
     specified, ``n`` will be converted to the highest unit possible. If
     no ``unit`` nor ``to`` is specified, the output will be binary units
@@ -131,7 +129,7 @@ def convert_units(n, unit=BYTE, to=None, si=False, exact=False):
     :rtype: tuple(quantity, string)
     """
     if unit not in PREFIXES:
-        raise ValueError('{} is not a valid binary unit.'.format(unit))
+        raise ValueError(f'{unit} is not a valid binary unit.')
 
     # Always work with bytes to simplify logic.
     n *= Decimal(unit) if exact else unit
@@ -140,7 +138,7 @@ def convert_units(n, unit=BYTE, to=None, si=False, exact=False):
         try:
             return n / to, PREFIXES[to]
         except KeyError:
-            raise ValueError('{} is not a valid binary unit.'.format(to))
+            raise ValueError(f'{to} is not a valid binary unit.')
 
     if unit in BINARY_PREFIXES and not si:
         if n < KIBIBYTE:

--- a/binary/utils.py
+++ b/binary/utils.py
@@ -5,32 +5,28 @@ class Decimal(_Decimal):
     def __new__(cls, value='0', context=None):
         if isinstance(value, float):
             value = str(value)
-        return super(Decimal, cls).__new__(cls, value, context)
+        return super().__new__(cls, value, context)
 
     def __add__(self, other, context=None):
         if isinstance(other, float):
             other = Decimal(other)
-        return Decimal(super(Decimal, self).__add__(other))
+        return Decimal(super().__add__(other))
     __radd__ = __add__
 
     def __sub__(self, other, context=None):
         if isinstance(other, float):
             other = Decimal(other)
-        return Decimal(super(Decimal, self).__sub__(other))
+        return Decimal(super().__sub__(other))
     __rsub__ = __sub__
 
     def __mul__(self, other, context=None):
         if isinstance(other, float):
             other = Decimal(other)
-        return Decimal(super(Decimal, self).__mul__(other))
+        return Decimal(super().__mul__(other))
     __rmul__ = __mul__
 
     def __truediv__(self, other, context=None):
         if isinstance(other, float):
             other = Decimal(other)
-        return Decimal(super(Decimal, self).__truediv__(other))
+        return Decimal(super().__truediv__(other))
     __rtruediv__ = __truediv__
-
-    # TODO: remove when Python 2 EOL
-    __div__ = __truediv__
-    __rdiv__ = __rtruediv__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = 'MIT/Apache-2.0'
 url = 'https://github.com/ofek/binary'
 
 [requires]
-python_version = ['2.7', '3.5', '3.6', 'pypy', 'pypy3']
+python_version = ['3.6', '3.7', '3.8', '3.9', 'pypy3']
 
 [build-system]
 requires = ['setuptools', 'wheel']

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@
 # please add your changes near the bottom marked for 'USER OVERRIDES'.
 # EVERYTHING ELSE WILL BE OVERWRITTEN by hatch.
 #############################################################
-from io import open
-
 from setuptools import find_packages, setup
 
-with open('binary/__init__.py', 'r') as f:
+with open('binary/__init__.py') as f:
     for line in f:
         if line.startswith('__version__'):
             version = line.strip().split('=')[1].strip(' \'"')
@@ -15,7 +13,7 @@ with open('binary/__init__.py', 'r') as f:
     else:
         version = '0.0.1'
 
-with open('README.rst', 'r', encoding='utf-8') as f:
+with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 REQUIRES = []
@@ -38,12 +36,16 @@ kwargs = {
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
+    'python_requires': '>=3.6',
     'install_requires': REQUIRES,
     'tests_require': ['coverage', 'pytest'],
     'packages': find_packages(),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import pytest
 
 import binary

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,5 @@
 [tox]
-envlist =
-    py27,
-    py35,
-    py36,
-    pypy,
-    pypy3,
+envlist = py{36,37,38,39,py3}
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Python < 3.5 is end of life. They are no longer receiving bug fixes,
including for security issues. Here is a list of end of life Pythons and
their dates:

https://devguide.python.org/devcycle/#end-of-life-branches

By removing support for these, the project is in a better position to
adopt newer Python features. For example, type annotations.

This also reduces testing and support resources.