### PR TITLE
Remove support for end-of-life Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = 'MIT/Apache-2.0'
 url = 'https://github.com/ofek/binary'
 
 [requires]
-python_version = ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+python_version = ['3.7', '3.8', '3.9', '3.10', 'pypy3']
 
 [build-system]
 requires = ['setuptools', 'wheel']

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,15 +17,15 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 packages = binary
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,py3}, mypy
+envlist = py{37,38,39,310,py3}, mypy
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Python 3.6 has been EOL since 2021-12-23.

https://devguide.python.org/devcycle/#end-of-life-branches

Also add Python 3.10 to documented list of supported versions.