### PR TITLE
Remove invalid escape character

### DIFF
--- a/binary/core.py
+++ b/binary/core.py
@@ -140,7 +140,7 @@ def convert_units(
     Decimal units conform to SI standards, see:
     https://en.wikipedia.org/wiki/International_System_of_Units
 
-    :param n: The number of ``unit``\ s.
+    :param n: The number of ``unit``s.
     :type n: ``int`` or ``float``
     :param unit: The unit ``n`` represents.
     :type unit: one of the global constants


### PR DESCRIPTION
When using Python 3.12, we're seeing the following warning:
```
SyntaxWarning: invalid escape sequence '\ '
```

The space character doesn't seem to be escapable https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences.